### PR TITLE
Complement com.cuperino.qprompt.appdata.xml

### DIFF
--- a/com.cuperino.qprompt.appdata.xml
+++ b/com.cuperino.qprompt.appdata.xml
@@ -10,6 +10,7 @@
   <url type="bugtracker">https://github.com/Cuperino/QPrompt/issues</url>
   <url type="help">https://forum.cuperino.com/</url>
   <url type="donation">https://www.patreon.com/qpromptapp</url>
+  <url type="vcs-browser">https://github.com/Cuperino/QPrompt-Teleprompter</url>
   <metadata_license>CC-BY-4.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <developer_name>Javier O. Cordero Pérez</developer_name>
@@ -27,6 +28,11 @@
       <caption>Countdown on stand-by</caption>
     </screenshot>
   </screenshots>
+  <categories>
+    <category>Qt</category>
+    <category>AudioVideo</category>
+    <category>Video</category>
+  </categories>
   <provides>
     <binary>qprompt</binary>
     <mediatype>text/plain</mediatype>


### PR DESCRIPTION
Based on what is already available in the [LinuxPhoneApps listing](https://linuxphoneapps.org/apps/com.cuperino.qprompt/) I added some missing metainfo:

* Adds vcs-browser url
* Adds categories