### PR TITLE
Add INTERNET permission to Android manifest

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -45,6 +45,7 @@
         </activity>
     </application>
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>


### PR DESCRIPTION
The Android manifest doesn't declare `android.permission.INTERNET`, so anything that opens a socket fails silently on Android — no permission prompt, the request just never goes through.

Two features depend on it:

- **Open from network** — loads a script from a URL, with optional auto-reload (`networkDialog` in `PrompterPage.qml`, also reachable from the Android menu in `+android/main.qml`).
- **OBS WebSocket** integration in `Prompter.qml`.

Both open a socket under the hood (`QNetworkAccessManager` / `QtWebSockets`), and neither can connect on Android without this. It's a normal install-time permission, so there's no runtime request involved.

**Known limitation:** this restores HTTPS/WSS connections. Plaintext `http://`/`ws://` will still be blocked on Android 9+ because cleartext traffic is off by default (no `usesCleartextTraffic` / network-security-config set). That's a separate change, out of scope here.