### PR TITLE
fix(editor): filter pasted HTML from the toolbar button and File menu

### DIFF
--- a/src/kirigami_ui/EditorToolbar.qml
+++ b/src/kirigami_ui/EditorToolbar.qml
@@ -342,7 +342,7 @@ ToolBar {
                 font.pointSize: 13
                 focusPolicy: Qt.TabFocus
                 enabled: viewport.prompter.editor.canPaste
-                onClicked: viewport.prompter.editor.paste()
+                onClicked: viewport.prompter.document.paste()
             }
             ToolSeparator {
                 contentItem.visible: mobileOrSmallScreen ? editRow.y === alignmentRowMobile.y : editRow.y === formatRow.y

--- a/src/kirigami_ui/main.qml
+++ b/src/kirigami_ui/main.qml
@@ -683,7 +683,7 @@ Kirigami.ApplicationWindow {
             Labs.MenuItem {
                 text: qsTr("&Paste", "Global menu and editor context menu actions")
                 enabled: root.pageStack.currentItem.editor.canPaste
-                onTriggered: root.pageStack.currentItem.editor.paste()
+                onTriggered: root.pageStack.currentItem.document.paste()
             }
         },
 


### PR DESCRIPTION
The toolbar Paste button and the File menu's Paste action called the editor's raw `paste()`, bypassing the `filterHtml()` pass that Ctrl+V and the context menu already use through `document.paste()`. That filter strips hardcoded font sizes and forced text colors so pasted content scales with the prompter and matches the surrounding style.

Routing both actions through `document.paste()` makes every paste entry point filter consistently.

(Compiled and verified fix on Windows)