### PR TITLE
fix(editor): stop Replace All from hanging on regex searches

### DIFF
--- a/src/documenthandler.cpp
+++ b/src/documenthandler.cpp
@@ -1549,7 +1549,7 @@ QPoint DocumentHandler::search(const QString &subString, const bool next, const 
         else
             cursor = this->textDocument()->find(searchRegEx, this->selectionStart(), QTextDocument::FindCaseSensitively);
         // If no more results, go to the corresponding start position and do the search once more
-        if (cursor.selectionStart() == -1 && cursor.selectionStart() == -1 && cursor.selectionEnd() == -1) {
+        if (loop && (cursor.selectionStart() == -1 && cursor.selectionStart() == -1 && cursor.selectionEnd() == -1)) {
             if (reverse)
                 cursor =
                     this->textDocument()->find(searchRegEx, textDocument()->characterCount(), QTextDocument::FindBackward | QTextDocument::FindCaseSensitively);


### PR DESCRIPTION
With regex enabled, Replace All can hang the app when the replacement text also matches the search pattern (i.e. replacing `a` with `aa`).

`replaceAll()` calls `search()` with `loop=false` so it stops once matches run out. The plain-text branch honors that flag; the regex branch ignored it and always wrapped back to the top, re-finding the just-inserted text and looping forever.

Fix gates the regex wrap-around on `loop`, matching the plain-text branch (one line in `DocumentHandler::search()`). Only `replaceAll()` passes `loop=false`, so interactive Find is unaffected.