### PR TITLE
fix(build): register 3rdparty/breeze-icons submodule in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,9 @@
 [submodule "3rdparty/kcrash"]
 	path = 3rdparty/kcrash
 	url = https://invent.kde.org/frameworks/kcrash.git
+[submodule "3rdparty/breeze-icons"]
+	path = 3rdparty/breeze-icons
+	url = https://invent.kde.org/frameworks/breeze-icons.git
 [submodule "3rdparty/QHotkey"]
 	path = 3rdparty/QHotkey
 	url = https://github.com/Cuperino/QHotkey.git


### PR DESCRIPTION
`3rdparty/breeze-icons` is committed as a submodule (gitlink) but is the only one missing from `.gitmodules`, so `git submodule update --init --recursive` skips it (the directory stays empty and `BreezeIconSubset.cmake` then aborts configure
with a FATAL_ERROR on every fresh clone).

Adds the missing entry.