### PR TITLE
fix(units): register Units duration enum as a QML type

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,7 +76,7 @@ endif()
 
 set(qprompt_cpp
     qmlutil.hpp
-    abstractunits.hpp
+    units.hpp
     marker.hpp
     documenthandler.h documenthandler.cpp
     markersmodel.h markersmodel.cpp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@
 #endif
 
 #include "../qprompt_version.h"
-#include "abstractunits.hpp"
+#include "units.hpp"
 //#include "documenthandler.h"
 //#include "qmlutil.hpp"
 #include <stdlib.h>
@@ -216,7 +216,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     //    qmlRegisterType<DocumentHandler>(QPROMPT_URI ".document", 1, 0, "DocumentHandler");
     //    qmlRegisterType<MarkersModel>(QPROMPT_URI ".markers", 1, 0, "MarkersModel");
     //    qmlRegisterType<QmlUtil>(QPROMPT_URI ".qmlutil", 1, 0, "QmlUtil");
-    //    qmlRegisterUncreatableType</*AbstractUnits*/>(QPROMPT_URI ".abstractunits", 1, 0, "Units", "Access to Duration enum");
+    //    qmlRegisterUncreatableType</*Units*/>(QPROMPT_URI ".units", 1, 0, "Units", "Access to Duration enum");
     QQmlApplicationEngine engine;
     // qmlRegisterType<PrompterWindow>(QPROMPT_URI".prompterwindow", 1, 0, "PrompterWindow");
 

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -24,9 +24,10 @@
 #include <QObject>
 #include <QQmlEngine>
 
-class AbstractUnits : public QObject
+class Units : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     QML_UNCREATABLE("Cannot create")
 
 public:


### PR DESCRIPTION
`AbstractUnits` has `QML_UNCREATABLE` but no `QML_ELEMENT`, so it's never registered — `QML_UNCREATABLE` only marks an already-registered element. The QML uses it as `Units` (`duration: Units.ShortDuration`), so every reference throws `ReferenceError: Units is not defined` and the animations/timers fall back to defaults.

Add `QML_NAMED_ELEMENT(Units)`.