### PR TITLE
fix(prompter): gate sys:// command markers behind explicit opt-in

### DIFF
--- a/src/kirigami_ui/PrompterPage.qml
+++ b/src/kirigami_ui/PrompterPage.qml
@@ -1223,6 +1223,22 @@ Kirigami.Page {
                     }
                 }
             }
+            CheckBox {
+                id: systemCommandsCheck
+                Layout.fillWidth: true
+                visible: ['android', 'ios', 'wasm'].indexOf(Qt.platform.os) === -1
+                text: qsTr("Allow sys:// markers to run system commands", "Security opt-in beneath the marker command field. Off by default; when checked, sys:// markers in a document may execute local system commands as the prompter scrolls past them.")
+                checked: prompter.systemCommandsEnabled
+                onToggled: prompter.systemCommandsEnabled = checked
+                // Wrap rather than elide, so the label fits the fixed-width sheet in any
+                // translation — Text.Wrap also breaks overlong words (e.g. German compounds).
+                contentItem: Label {
+                    text: systemCommandsCheck.text
+                    wrapMode: Text.Wrap
+                    verticalAlignment: Text.AlignVCenter
+                    leftPadding: systemCommandsCheck.indicator.width + systemCommandsCheck.spacing
+                }
+            }
         }
     }
 

--- a/src/prompter/Prompter.qml
+++ b/src/prompter/Prompter.qml
@@ -278,6 +278,12 @@ Flickable {
         property alias url: ws.urlString
         property alias password: ws.password
     }
+    // Off by default so an untrusted document can't run sys:// commands unprompted.
+    property bool systemCommandsEnabled: false
+    Settings {
+        category: "system"
+        property alias enabled: prompter.systemCommandsEnabled
+    }
     Connections {
         target: AppController
         function interalFocusElsewhere() {
@@ -412,7 +418,7 @@ Flickable {
                     }
                     ws.sendTextMessage(JSON.stringify(req));
                 }
-                else if (m.url.startsWith("sys://"))
+                else if (systemCommandsEnabled && m.url.startsWith("sys://"))
                     qmlutil.run(m.url.slice(6));
             }
             q = p;


### PR DESCRIPTION
## Bug (potential vulnerability)
A marker's `sys://` href is passed straight to `QProcess::startDetached()` unsanitised and without opt-in, so merely opening and prompting an untrusted document can run arbitrary commands with the user's privileges (e.g. `<a href="sys://calc">cue: intro</a>`).

## Partial Fix
Gate the `sys://` dispatch behind a persisted `systemCommandsEnabled` setting, **off by default**, with an opt-in checkbox.

Dunno if this needs anything else for other platforms but its verified fix on Windows.